### PR TITLE
fill experimental BKT params from fitted model

### DIFF
--- a/bkt-params/experimentalBKTParams.json
+++ b/bkt-params/experimentalBKTParams.json
@@ -6,10 +6,10 @@
         "probGuess": 0.1
     },
     "intervals_for_prediction_&_knn_classification": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.20601,
+        "probTransit": 0.037831,
+        "probSlip": 0.124622,
+        "probGuess": 0.338371
     },
     "residuals": {
         "probMastery": 0.1,
@@ -36,136 +36,136 @@
         "probGuess": 0.1
     },
     "models": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.13909,
+        "probTransit": 0.0077,
+        "probSlip": 0.225893,
+        "probGuess": 0.436947
     },
     "chance": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.156353,
+        "probTransit": 0.007732,
+        "probSlip": 0.230704,
+        "probGuess": 0.415903
     },
     "conditionals": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.119216,
+        "probTransit": 0.004981,
+        "probSlip": 0.082846,
+        "probGuess": 0.37251
     },
     "iteration": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.119377,
+        "probTransit": 0.004987,
+        "probSlip": 0.083019,
+        "probGuess": 0.372475
     },
     "table_methods": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.119281,
+        "probTransit": 0.004984,
+        "probSlip": 0.082915,
+        "probGuess": 0.372496
     },
     "functions": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.388668,
+        "probTransit": 0.187981,
+        "probSlip": 0.086757,
+        "probGuess": 0.124606
     },
     "visualizations": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.400084,
+        "probTransit": 0.046455,
+        "probSlip": 0.08022,
+        "probGuess": 0.273661
     },
     "and_least_common_multiples": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.148832,
+        "probTransit": 0.058909,
+        "probSlip": 0.10214,
+        "probGuess": 0.262871
     },
     "evaluate_an_expression": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.525529,
+        "probTransit": 0.138711,
+        "probSlip": 0.027865,
+        "probGuess": 0.513465
     },
     "find_factors": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.148477,
+        "probTransit": 0.058673,
+        "probSlip": 0.101915,
+        "probGuess": 0.263656
     },
     "identify_and_combine_like_terms": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.610217,
+        "probTransit": 0.044248,
+        "probSlip": 0.089793,
+        "probGuess": 0.48094
     },
     "prime_factorizations": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.148869,
+        "probTransit": 0.059003,
+        "probSlip": 0.10221,
+        "probGuess": 0.262616
     },
     "simplify_expressions_using_the_order_of_operations": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.605409,
+        "probTransit": 0.027501,
+        "probSlip": 0.048058,
+        "probGuess": 0.614261
     },
     "translate_an_english_phrase_to_an_algebraic_expression": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.543907,
+        "probTransit": 0.107993,
+        "probSlip": 0.10336,
+        "probGuess": 0.139453
     },
     "add_and_subtract_fractions": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.456185,
+        "probTransit": 0.072313,
+        "probSlip": 0.115365,
+        "probGuess": 0.299936
     },
     "evaluate_variable_expressions_with_fractions": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.19376,
+        "probTransit": 0.110127,
+        "probSlip": 0.000143,
+        "probGuess": 0.245544
     },
     "multiply_and_divide_fractions": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.456185,
+        "probTransit": 0.072313,
+        "probSlip": 0.115365,
+        "probGuess": 0.299936
     },
     "simplify_fractions": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.7841,
+        "probTransit": 0.109119,
+        "probSlip": 0.003325,
+        "probGuess": 0.451709
     },
     "use_the_order_of_operations_to_simplify_fractions": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.208921,
+        "probTransit": 0.103,
+        "probSlip": 0.04906,
+        "probGuess": 0.108549
     },
     "add_integers": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.673445,
+        "probTransit": 0.274553,
+        "probSlip": 0.071204,
+        "probGuess": 0.533071
     },
     "simplify:_expressions_with_absolute_value": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.456185,
+        "probTransit": 0.072313,
+        "probSlip": 0.115365,
+        "probGuess": 0.299936
     },
     "use_negatives_and_opposites_of_integers": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.858112,
+        "probTransit": 0.094882,
+        "probSlip": 0.043147,
+        "probGuess": 0.453737
     },
     "solve_equations_that_require_simplification": {
         "probMastery": 0.1,
@@ -174,28 +174,28 @@
         "probGuess": 0.1
     },
     "solve_equations_using_the_division_and_multiplication_properties_of_equality": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.41527,
+        "probTransit": 0.014252,
+        "probSlip": 0.083644,
+        "probGuess": 0.462446
     },
     "solve_equations_using_the_subtraction_and_addition_properties_of_equality": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.315548,
+        "probTransit": 0.173239,
+        "probSlip": 0.138918,
+        "probGuess": 0.025934
     },
     "simplify_expressions_using_the_distributive_property": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.276247,
+        "probTransit": 0.002424,
+        "probSlip": 0.066226,
+        "probGuess": 0.352114
     },
     "use_the_commutative_and_associative_properties": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.720466,
+        "probTransit": 0.043095,
+        "probSlip": 0.103419,
+        "probGuess": 0.130257
     },
     "and_time_formula": {
         "probMastery": 0.1,
@@ -210,10 +210,10 @@
         "probGuess": 0.1
     },
     "solve_a_formula_for_a_specific_variable": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.434457,
+        "probTransit": 0.000673,
+        "probSlip": 0.187329,
+        "probGuess": 0.356657
     },
     "solve_linear_equations_using_a_general_strategy": {
         "probMastery": 0.1,
@@ -294,10 +294,10 @@
         "probGuess": 0.1
     },
     "solve_linear_inequalities": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.589275,
+        "probTransit": 0.004557,
+        "probSlip": 0.227959,
+        "probGuess": 0.326634
     },
     "solving_compound_inequalities": {
         "probMastery": 0.1,
@@ -462,10 +462,10 @@
         "probGuess": 0.1
     },
     "recognize_and_use_the_appropriate_method_to_factor_a_polynomial_completely": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.448382,
+        "probTransit": 0.051001,
+        "probSlip": 0.141311,
+        "probGuess": 0.231575
     },
     "complete_the_square_of_a_binomial_expression": {
         "probMastery": 0.1,
@@ -612,16 +612,16 @@
         "probGuess": 0.1
     },
     "writing_the_equation_of_lines_parallel_or_perpendicular_to_a_given_line": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.398068,
+        "probTransit": 0.075781,
+        "probSlip": 0.234417,
+        "probGuess": 0.225291
     },
     "determining_whether_graphs_of_lines_are_parallel_or_perpendicular": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.456185,
+        "probTransit": 0.072313,
+        "probSlip": 0.115365,
+        "probGuess": 0.299936
     },
     "use_slopes_to_identify_perpendicular_lines": {
         "probMastery": 0.1,
@@ -882,82 +882,82 @@
         "probGuess": 0.1
     },
     "finding_the_power_of_a_product": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.456185,
+        "probTransit": 0.072313,
+        "probSlip": 0.115365,
+        "probGuess": 0.299936
     },
     "finding_the_quotient_of_a_product": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.456185,
+        "probTransit": 0.072313,
+        "probSlip": 0.115365,
+        "probGuess": 0.299936
     },
     "using_scientific_notation": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.492275,
+        "probTransit": 0.014444,
+        "probSlip": 0.27878,
+        "probGuess": 0.155621
     },
     "using_the_negative_exponent_rule_of_exponents": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.667635,
+        "probTransit": 0.058844,
+        "probSlip": 0.121173,
+        "probGuess": 0.2586
     },
     "using_the_power_rule_of_exponents": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.456185,
+        "probTransit": 0.072313,
+        "probSlip": 0.115365,
+        "probGuess": 0.299936
     },
     "using_the_product_exponent_rule_of_exponents": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.635261,
+        "probTransit": 0.312647,
+        "probSlip": 0.025038,
+        "probGuess": 0.199775
     },
     "using_the_quotient_exponent_rule_of_exponents": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.456185,
+        "probTransit": 0.072313,
+        "probSlip": 0.115365,
+        "probGuess": 0.299936
     },
     "using_the_quotient_rule_of_exponents": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.456185,
+        "probTransit": 0.072313,
+        "probSlip": 0.115365,
+        "probGuess": 0.299936
     },
     "using_the_zero_exponent_rule_of_exponents": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.456185,
+        "probTransit": 0.072313,
+        "probSlip": 0.115365,
+        "probGuess": 0.299936
     },
     "find_prime_factorizations_and_least_common_multiples": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.312754,
+        "probTransit": 0.060026,
+        "probSlip": 0.142574,
+        "probGuess": 0.190131
     },
     "and_real_numbers": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.520109,
+        "probTransit": 0.100822,
+        "probSlip": 0.021457,
+        "probGuess": 0.563787
     },
     "identify_integers": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.521598,
+        "probTransit": 0.099615,
+        "probSlip": 0.021458,
+        "probGuess": 0.56424
     },
     "irrational_numbers": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.523153,
+        "probTransit": 0.099306,
+        "probSlip": 0.02148,
+        "probGuess": 0.563502
     },
     "locate_decimals_on_the_number_line": {
         "probMastery": 0.1,
@@ -966,10 +966,10 @@
         "probGuess": 0.1
     },
     "rational_numbers": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.52399,
+        "probTransit": 0.099337,
+        "probSlip": 0.021497,
+        "probGuess": 0.562851
     },
     "simplify_expressions_with_square_roots": {
         "probMastery": 0.1,
@@ -1182,16 +1182,16 @@
         "probGuess": 0.1
     },
     "key_terms": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.636614,
+        "probTransit": 0.016777,
+        "probSlip": 0.280118,
+        "probGuess": 0.394883
     },
     "quantitative_and_qualitative_data": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.637042,
+        "probTransit": 0.001356,
+        "probSlip": 0.232762,
+        "probGuess": 0.483142
     },
     "frequency": {
         "probMastery": 0.1,
@@ -1884,16 +1884,16 @@
         "probGuess": 0.1
     },
     "algebra_with_absolute_values": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.709718,
+        "probTransit": 0.000931,
+        "probSlip": 0.297804,
+        "probGuess": 0.256908
     },
     "algebra_with_exponents_and_logarithms": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.325369,
+        "probTransit": 1.4e-05,
+        "probSlip": 6.2e-05,
+        "probGuess": 0.346292
     },
     "geometry_and_algebra": {
         "probMastery": 0.1,
@@ -1908,10 +1908,10 @@
         "probGuess": 0.1
     },
     "core_functions:_exponential_and_logarithmic": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.32795,
+        "probTransit": 0.002182,
+        "probSlip": 0.370181,
+        "probGuess": 0.252997
     },
     "algebra_with_inequalities": {
         "probMastery": 0.1,
@@ -1926,10 +1926,10 @@
         "probGuess": 0.1
     },
     "composition_of_functions": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.380876,
+        "probTransit": 0.059047,
+        "probSlip": 0.128084,
+        "probGuess": 0.308362
     },
     "transformations_of_functions": {
         "probMastery": 0.1,
@@ -1950,16 +1950,16 @@
         "probGuess": 0.1
     },
     "accuracy": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.423457,
+        "probTransit": 0.056648,
+        "probSlip": 0.140769,
+        "probGuess": 0.321794
     },
     "and_significant_figures": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.423457,
+        "probTransit": 0.056648,
+        "probSlip": 0.140769,
+        "probGuess": 0.321794
     },
     "approximation": {
         "probMastery": 0.1,
@@ -1974,10 +1974,10 @@
         "probGuess": 0.1
     },
     "precision": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.423457,
+        "probTransit": 0.056648,
+        "probSlip": 0.140769,
+        "probGuess": 0.321794
     },
     "kinematics": {
         "probMastery": 0.1,
@@ -2160,10 +2160,10 @@
         "probGuess": 0.1
     },
     "review_of_functions": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.155365,
+        "probTransit": 0.026233,
+        "probSlip": 0.49199,
+        "probGuess": 0.121344
     },
     "symmetry_of_functions": {
         "probMastery": 0.1,
@@ -2172,10 +2172,10 @@
         "probGuess": 0.1
     },
     "linear_functions_and_slope": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.149704,
+        "probTransit": 7.6e-05,
+        "probSlip": 0.0,
+        "probGuess": 0.349199
     },
     "polynomials": {
         "probMastery": 0.1,
@@ -2544,52 +2544,52 @@
         "probGuess": 0.1
     },
     "evaluating_a_function_given_in_tabular_form_in_openstax_precalc": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.609023,
+        "probTransit": 0.073836,
+        "probSlip": 0.082411,
+        "probGuess": 0.279737
     },
     "evaluating_functions_expressed_in_formulas_in_openstax_precalc": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.057118,
+        "probTransit": 0.055431,
+        "probSlip": 0.106473,
+        "probGuess": 0.19834
     },
     "evaluation_of_functions_in_algebra_forms_in_openstax_precalc": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.48878,
+        "probTransit": 0.006505,
+        "probSlip": 0.414212,
+        "probGuess": 0.284921
     },
     "representing_functions_using_tables_in_openstax_precalc": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.696151,
+        "probTransit": 0.103972,
+        "probSlip": 0.195972,
+        "probGuess": 0.487481
     },
     "using_function_notation_in_openstax_precalc": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.380876,
+        "probTransit": 0.059047,
+        "probSlip": 0.128084,
+        "probGuess": 0.308362
     },
     "using_the_horizontal_line_test_in_openstax_precalc": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.380876,
+        "probTransit": 0.059047,
+        "probSlip": 0.128084,
+        "probGuess": 0.308362
     },
     "using_the_vertical_line_test_in_openstax_precalc": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.380876,
+        "probTransit": 0.059047,
+        "probSlip": 0.128084,
+        "probGuess": 0.308362
     },
     "domain_and_range": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.247905,
+        "probTransit": 0.017373,
+        "probSlip": 0.356171,
+        "probGuess": 0.078761
     },
     "finding_domain_and_ranges": {
         "probMastery": 0.1,
@@ -2598,10 +2598,10 @@
         "probGuess": 0.1
     },
     "rates_of_change_and_behavior_of_graphs": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.380876,
+        "probTransit": 0.059047,
+        "probSlip": 0.128084,
+        "probGuess": 0.308362
     },
     "composition_of_functions_in_openstax_precalc": {
         "probMastery": 0.1,
@@ -2646,28 +2646,28 @@
         "probGuess": 0.1
     },
     "linear_functions": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.227901,
+        "probTransit": 0.035619,
+        "probSlip": 0.068945,
+        "probGuess": 0.210518
     },
     "graph_of_linear_functions": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.046873,
+        "probTransit": 0.042217,
+        "probSlip": 5.6e-05,
+        "probGuess": 0.385363
     },
     "modeling_with_linear_functions": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.328185,
+        "probTransit": 0.034371,
+        "probSlip": 0.04667,
+        "probGuess": 0.214896
     },
     "fitting_linear_models_to_data": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.060123,
+        "probTransit": 0.021853,
+        "probSlip": 0.145854,
+        "probGuess": 0.274774
     },
     "complex_numbers": {
         "probMastery": 0.1,
@@ -2676,10 +2676,10 @@
         "probGuess": 0.1
     },
     "quadratic_functions": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.336146,
+        "probTransit": 2.1e-05,
+        "probSlip": 0.29631,
+        "probGuess": 0.285952
     },
     "power_functions_and_polynomial_functions": {
         "probMastery": 0.1,
@@ -2844,22 +2844,22 @@
         "probGuess": 0.1
     },
     "angles": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.403745,
+        "probTransit": 0.092698,
+        "probSlip": 0.085464,
+        "probGuess": 0.474906
     },
     "finding_function_values_for_the_sine_and_cosine": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.215754,
+        "probTransit": 0.126024,
+        "probSlip": 0.000634,
+        "probGuess": 0.36498
     },
     "finding_reference_angle": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.1874,
+        "probTransit": 0.128841,
+        "probSlip": 0.172332,
+        "probGuess": 0.291852
     },
     "finding_sines_and_cosines_of_special_angles": {
         "probMastery": 0.1,
@@ -2874,10 +2874,10 @@
         "probGuess": 0.1
     },
     "real_world_applications": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.170149,
+        "probTransit": 0.020621,
+        "probSlip": 4.6e-05,
+        "probGuess": 0.38609
     },
     "the_pythagorean_identity": {
         "probMastery": 0.1,
@@ -2886,10 +2886,10 @@
         "probGuess": 0.1
     },
     "using_reference_angle_to_find_sine_and_cosine": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.444404,
+        "probTransit": 0.021319,
+        "probSlip": 0.066342,
+        "probGuess": 0.348378
     },
     "using_reference_angles_to_find_coordinates": {
         "probMastery": 0.1,
@@ -3240,22 +3240,22 @@
         "probGuess": 0.1
     },
     "identify_multiples_and_apply_divisibility_tests": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.49962,
+        "probTransit": 0.078437,
+        "probSlip": 0.152773,
+        "probGuess": 0.516322
     },
     "use_place_value_with_whole_numbers": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.342845,
+        "probTransit": 0.040001,
+        "probSlip": 0.161446,
+        "probGuess": 0.337909
     },
     "use_variables_and_algebraic_symbols": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.298541,
+        "probTransit": 0.048738,
+        "probSlip": 0.001069,
+        "probGuess": 0.552636
     },
     "divide_integers": {
         "probMastery": 0.1,
@@ -3264,10 +3264,10 @@
         "probGuess": 0.1
     },
     "evaluate_variable_expressions_with_integers": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.456185,
+        "probTransit": 0.072313,
+        "probSlip": 0.115365,
+        "probGuess": 0.299936
     },
     "multiply_integers": {
         "probMastery": 0.1,
@@ -3276,16 +3276,16 @@
         "probGuess": 0.1
     },
     "simplify_expressions_with_integers": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.456185,
+        "probTransit": 0.072313,
+        "probSlip": 0.115365,
+        "probGuess": 0.299936
     },
     "translate_phrases_to_expressions_with_integers": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.364673,
+        "probTransit": 0.083066,
+        "probSlip": 0.049927,
+        "probGuess": 0.16996
     },
     "use_integers_in_applications": {
         "probMastery": 0.1,
@@ -3894,10 +3894,10 @@
         "probGuess": 0.1
     },
     "multiply_and_divide_integers": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.594969,
+        "probTransit": 0.034939,
+        "probSlip": 0.204922,
+        "probGuess": 0.179191
     },
     "simplify_and_evaluate_expressions_with_integers": {
         "probMastery": 0.1,
@@ -4494,28 +4494,28 @@
         "probGuess": 0.1
     },
     "classifying_a_real_number": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.456185,
+        "probTransit": 0.072313,
+        "probSlip": 0.115365,
+        "probGuess": 0.299936
     },
     "evaluating_algebraic_expressions": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.540487,
+        "probTransit": 0.013125,
+        "probSlip": 0.145899,
+        "probGuess": 0.291396
     },
     "performing_calculations_using_the_order_of_operations": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.608349,
+        "probTransit": 0.059348,
+        "probSlip": 0.155246,
+        "probGuess": 0.19725
     },
     "evaluating_square_roots": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.456185,
+        "probTransit": 0.072313,
+        "probSlip": 0.115365,
+        "probGuess": 0.299936
     },
     "rationalizing_denominators": {
         "probMastery": 0.1,
@@ -4524,10 +4524,10 @@
         "probGuess": 0.1
     },
     "using_rational_roots": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.460025,
+        "probTransit": 0.01326,
+        "probSlip": 0.411833,
+        "probGuess": 0.127806
     },
     "adding_and_subtracting_polynomials": {
         "probMastery": 0.1,
@@ -4536,10 +4536,10 @@
         "probGuess": 0.1
     },
     "multiplying_polynomials": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.456185,
+        "probTransit": 0.072313,
+        "probSlip": 0.115365,
+        "probGuess": 0.299936
     },
     "factoring_a_difference_of_squares": {
         "probMastery": 0.1,
@@ -4608,82 +4608,82 @@
         "probGuess": 0.1
     },
     "finding_x_intercepts_and_y_intercepts": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.257336,
+        "probTransit": 0.023452,
+        "probSlip": 0.213492,
+        "probGuess": 0.175793
     },
     "using_the_distance_formula": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.456185,
+        "probTransit": 0.072313,
+        "probSlip": 0.115365,
+        "probGuess": 0.299936
     },
     "using_the_midpoint_formula": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.290166,
+        "probTransit": 0.084315,
+        "probSlip": 0.047291,
+        "probGuess": 0.087498
     },
     "finding_a_linear_equation": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.615073,
+        "probTransit": 0.025765,
+        "probSlip": 0.159619,
+        "probGuess": 0.204075
     },
     "solving_a_rational_equation": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.62796,
+        "probTransit": 0.105948,
+        "probSlip": 0.437396,
+        "probGuess": 0.183031
     },
     "solving_linear_equations_in_one_variable": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.364311,
+        "probTransit": 0.206325,
+        "probSlip": 0.242727,
+        "probGuess": 0.149935
     },
     "setting_up_a_linear_equation_to_solve_a_real_world_application": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.539514,
+        "probTransit": 0.027717,
+        "probSlip": 0.048616,
+        "probGuess": 0.257468
     },
     "using_a_formula_to_solve_a_real_world_application": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.240119,
+        "probTransit": 0.028439,
+        "probSlip": 0.034213,
+        "probGuess": 0.159602
     },
     "adding_and_subtracting_complex_numbers": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.428176,
+        "probTransit": 0.040719,
+        "probSlip": 0.010314,
+        "probGuess": 0.22024
     },
     "dividing_complex_numbers": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.171137,
+        "probTransit": 0.058465,
+        "probSlip": 0.000137,
+        "probGuess": 0.150442
     },
     "expressing_square_roots_of_negative_numbers_as_multiples_of_i": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.456185,
+        "probTransit": 0.072313,
+        "probSlip": 0.115365,
+        "probGuess": 0.299936
     },
     "multiplying_complex_numbers": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.482972,
+        "probTransit": 0.001658,
+        "probSlip": 0.195127,
+        "probGuess": 0.376833
     },
     "simplifying_powers_of_i": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.470369,
+        "probTransit": 0.028222,
+        "probSlip": 0.171206,
+        "probGuess": 0.260297
     },
     "completing_the_square": {
         "probMastery": 0.1,
@@ -4710,10 +4710,10 @@
         "probGuess": 0.1
     },
     "the_discriminant": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.456185,
+        "probTransit": 0.072313,
+        "probSlip": 0.115365,
+        "probGuess": 0.299936
     },
     "using_the_quadratic_formula": {
         "probMastery": 0.1,
@@ -4788,16 +4788,16 @@
         "probGuess": 0.1
     },
     "determining_whether_a_function_is_one_to_one": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.456185,
+        "probTransit": 0.072313,
+        "probSlip": 0.115365,
+        "probGuess": 0.299936
     },
     "determining_whether_a_relation_represents_a_function": {
-        "probMastery": 0.1,
-        "probTransit": 0.1,
-        "probSlip": 0.1,
-        "probGuess": 0.1
+        "probMastery": 0.456185,
+        "probTransit": 0.072313,
+        "probSlip": 0.115365,
+        "probGuess": 0.299936
     },
     "finding_input_and_output_values_of_a_function": {
         "probMastery": 0.1,


### PR DESCRIPTION
Updates experimentalBKTParams.json with fitted BKT parameters for
donor KCs and donor-average fill for disqualified/recipient KCs,
generated by the OATutor-Tooling BKT fitting pipeline.